### PR TITLE
ci: avoid ommiting releases

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ on:
 
 jobs:
   lint-test:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
     name: Lint & Test
     runs-on: ubuntu-latest
     steps:
@@ -46,7 +45,6 @@ jobs:
         run: yarn run test:ci
 
   release:
-    if: "!contains(github.event.head_commit.message, 'skip ci')"
     needs: lint-test
     runs-on: ubuntu-latest
     steps:

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -15,7 +15,7 @@
       "@semantic-release/git",
       {
         "assets": ["package.json", "docs/CHANGELOG.md"],
-        "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"
+        "message": "chore(release): ${nextRelease.version}\n\n${nextRelease.notes}"
       }
     ]
   ],


### PR DESCRIPTION
- using `skip ci` in commit messages prevents releases when merged to the main branch. 
- Reference: https://github.com/semantic-release/git#merging-between-semantic-release-branches